### PR TITLE
Stop split names from expanding to multiple rows

### DIFF
--- a/css/livesplit.css
+++ b/css/livesplit.css
@@ -200,6 +200,9 @@ table {
     width: 100%;
     padding-left: 0px !important;
     text-align: left !important;
+    max-width: 0;
+    white-space: nowrap;
+    overflow: hidden;
 }
 
 .split-icon-container {


### PR DESCRIPTION
More of a temporary solution since the split name text doesn't cut off where the delta text actually starts and times don't have constant widths. Probably need more divs to fix those issues, not sure.