### PR TITLE
Made layout the split/start button for mobile.

### DIFF
--- a/src/ui/LiveSplit.tsx
+++ b/src/ui/LiveSplit.tsx
@@ -125,16 +125,15 @@ export class LiveSplit extends React.Component<{}, State> {
                             margin: "10px",
                             marginBottom: "5px",
                         }}
-                    >
-                        <AutoRefreshLayout
-                            getState={() => this.state.timer.readWith(
-                                (t) => this.state.layout.stateAsJson(t),
-                            )}
-                        />
+                    >   
+                        <div onClick={(_) => this.onSplit()} style={{margin: "0px"}}>
+                            <AutoRefreshLayout
+                                getState={() => this.state.timer.readWith(
+                                    (t) => this.state.layout.stateAsJson(t),
+                                )}
+                            />
+                        </div>
                         <div className="buttons">
-                            <button onClick={(_) => this.onSplit()}>
-                                <i className="fa fa-play" aria-hidden="true" />
-                            </button>
                             <div className="small">
                                 <button onClick={(_) => this.onUndo()}>
                                     <i className="fa fa-arrow-up" aria-hidden="true" /></button>


### PR DESCRIPTION
The previous setup with the standalone split button was too annoying to
press on mobile. Now, the split button is gone and tapping on the
timer/splits will start the timer and split. This gives bit more
screen space for mobile as well. 

Resolves #45.