### PR TITLE
Support for importing and exporting layouts

### DIFF
--- a/src/ui/LiveSplit.tsx
+++ b/src/ui/LiveSplit.tsx
@@ -5,7 +5,7 @@ import {
     HotkeySystem, Layout, LayoutEditor, Run, RunEditor,
     Segment, SharedTimer, Timer, TimerPhase, TimingMethod,
 } from "../livesplit";
-import { exportFile, openFileAsArrayBuffer } from "../util/FileUtil";
+import { exportFile, openFileAsArrayBuffer, openFileAsString} from "../util/FileUtil";
 import { assertNull, expect, maybeDispose, maybeDisposeAndThen, Option } from "../util/OptionUtil";
 import * as SplitsIO from "../util/SplitsIO";
 import { LayoutEditor as LayoutEditorComponent } from "./LayoutEditor";
@@ -244,6 +244,26 @@ export class LiveSplit extends React.Component<{}, State> {
     public saveLayout() {
         const layout = this.state.layout.settingsAsJson();
         localStorage.setItem("layout", JSON.stringify(layout));
+    }
+
+    public importLayout() {
+        openFileAsString((file) => {
+            try {
+                /*XXX: I highly recommend replacing this routine with one that does not require a refresh*/
+                /*The line below this one throws an error if the file isnt valid json.*/
+                JSON.parse(file);
+                localStorage.setItem('layout', file);
+                /* I need the refresh as I could not get it to work without refreshing. */
+                if (confirm('Loading layouts requires a refresh. Continue?')) {location.reload();}
+            } catch(err) {
+                alert("Error loading layout (Are you sure this is a LiveSplit One layout?) - " + err);
+            }
+        });
+    }
+
+    public exportLayout() {
+        const layout = this.state.layout.settingsAsJson();
+        exportFile("layout.ls1l", JSON.stringify(layout));
     }
 
     public openRunEditor() {

--- a/src/ui/SideBarContent.tsx
+++ b/src/ui/SideBarContent.tsx
@@ -15,6 +15,8 @@ export interface SidebarCallbacks {
     uploadToSplitsIO(): void,
     openLayoutEditor(): void,
     saveLayout(): void,
+    importLayout(): void,
+    exportLayout(): void,
     switchToPreviousComparison(): void,
     switchToNextComparison(): void,
     setCurrentTimingMethod(timingMethod: TimingMethod): void,
@@ -125,6 +127,12 @@ export class SideBarContent extends React.Component<Props, State> {
                         </button>
                         <button onClick={(_) => this.props.callbacks.saveLayout()}>
                             <i className="fa fa-floppy-o" aria-hidden="true" /> Save Layout
+                        </button>
+                        <button onClick={(_) => this.props.callbacks.importLayout()}>
+                            <i className="fa fa-download" aria-hidden="true" /> Import Layout
+                        </button>
+                        <button onClick={(_) => this.props.callbacks.exportLayout()}>
+                            <i className="fa fa-upload" aria-hidden="true" /> Export Layout
                         </button>
                         <hr />
                         <h2>Compare Against</h2>

--- a/src/util/FileUtil.ts
+++ b/src/util/FileUtil.ts
@@ -18,6 +18,24 @@ export function openFileAsArrayBuffer(callback: (data: ArrayBuffer, file: File) 
     input.click();
 }
 
+export function openFileAsString(callback: (data: string, file: File) => void) {
+    const input = document.createElement("input");
+    input.setAttribute("type", "file");
+    input.onchange = (e: any) => {
+        const file: Option<File> = e.target.files[0];
+        if (file == null) {
+            return;
+        }
+        const reader = new FileReader();
+        reader.onload = (e: any) => {
+            const contents = e.target.result;
+            callback(contents, file);
+        };
+        reader.readAsText(file);
+    };
+    input.click();
+}
+
 export function exportFile(filename: string, data: any) {
     const url = URL.createObjectURL(new Blob([data], { type: "application/octet-stream" }));
     try {


### PR DESCRIPTION
I added support for importing and exporting layouts. As the format is different from the desktop version LiveSplit, I decided to use the extension of *.ls1l, instead of *.lsl to distinguish between the two formats. At the moment importing requires a refresh since I *could not* get it to work without a refresh. (Every other method I tried failed)

You can test my changes at https://theessenceofdarkness.github.io/livesplitone