### PR TITLE
Fixed the game icon in the title component, and some mobile issues.

### DIFF
--- a/src/css/livesplit.css
+++ b/src/css/livesplit.css
@@ -204,9 +204,11 @@ div.meta-left > div#lower-row > div.title-category {
 }
 
 img.title-icon {
-    min-width: 100%;
+    max-width: 100%;
     max-height: 100%;
     height: auto;
+    display: block;
+    margin: auto;
 }
 
 .splits {
@@ -479,36 +481,6 @@ input.name {
     border-top: 1.5px solid hsla(0, 0%, 100%, 0.2);
     margin: 0 -12px;
     bottom: -4px;
-}
-
-@media screen and (max-width: 425px) {
-    .editor-group {
-        display: list-item;
-    }
-    .btn-group {
-        display:flex;
-    }
-    .table {
-        display: flex;
-        width: 100%;
-        overflow-x: auto;
-    }
-    .table {
-        display: block;
-    }
-    .table>* {
-        display: block;
-    }
-    .table>*>* {
-        display: flex;
-    }
-    input.name {
-        width: 100px;
-    }
-    table.run-editor-table > tbody > tr > td > input {
-        width: 100px;
-        margin-right: -7px;
-    }
 }
 
 input {


### PR DESCRIPTION
The mobile specific css broke the split and layout editor on mobile (chrome for android specifically), requiring desktop mode to use them. Also, the game icon is no longer stretched in the title component.

Seperated these changes from #50 